### PR TITLE
Fix side-by-side diff panel width constraints

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -627,6 +627,12 @@
   flex-direction: row;
 }
 
+.vault-ai-diff-container.side-by-side .vault-ai-diff-panel {
+  width: 50%;
+  max-width: 50%;
+  flex: 0 0 50%;
+}
+
 .vault-ai-diff-container.unified {
   flex-direction: column;
 }


### PR DESCRIPTION
## Summary
Added explicit width constraints to diff panels in side-by-side view mode to ensure they properly occupy 50% of the container width each.

## Changes
- Added CSS rules for `.vault-ai-diff-container.side-by-side .vault-ai-diff-panel` to enforce equal width distribution
- Set `width: 50%` for explicit sizing
- Set `max-width: 50%` to prevent overflow
- Set `flex: 0 0 50%` to prevent flex shrinking/growing and maintain fixed basis

## Details
This ensures that when the diff container is in side-by-side mode, each panel takes up exactly half the available width, preventing layout issues where panels might not align properly or take up unequal space.

https://claude.ai/code/session_014UTrLCT3K6z3iaaFkQSuBm