### PR TITLE
Integrate new LMStudio API with streaming and reasoning support

### DIFF
--- a/src/chat/ChatHistoryManager.ts
+++ b/src/chat/ChatHistoryManager.ts
@@ -100,6 +100,20 @@ export class ChatHistoryManager {
     await this.save();
   }
 
+  async updateLMStudioResponseId(conversationId: string, responseId: string): Promise<void> {
+    const conversation = this.getConversation(conversationId);
+    if (!conversation) return;
+
+    conversation.lmStudioResponseId = responseId;
+    conversation.updatedAt = Date.now();
+    await this.save();
+  }
+
+  getLMStudioResponseId(conversationId: string): string | undefined {
+    const conversation = this.getConversation(conversationId);
+    return conversation?.lmStudioResponseId;
+  }
+
   async deleteConversation(id: string): Promise<void> {
     const index = this.history.conversations.findIndex((c) => c.id === id);
     if (index === -1) return;

--- a/src/llm/LMStudioClient.ts
+++ b/src/llm/LMStudioClient.ts
@@ -1,5 +1,26 @@
 import { LLMClient } from './LLMClient';
-import { LLMMessage } from '../types';
+import {
+  LLMMessage,
+  LMStudioChatRequest,
+  LMStudioNewChatResponse,
+  LMStudioStreamEvent,
+  LMStudioStreamCallbacks,
+} from '../types';
+
+export interface LMStudioChatOptions {
+  systemPrompt?: string;
+  previousResponseId?: string;
+  temperature?: number;
+  store?: boolean;
+  callbacks?: LMStudioStreamCallbacks;
+}
+
+export interface LMStudioChatResult {
+  content: string;
+  reasoning?: string;
+  responseId?: string;
+  stats?: LMStudioNewChatResponse['stats'];
+}
 
 export class LMStudioClient extends LLMClient {
   constructor(baseUrl: string = 'http://localhost:1234', model: string = '') {
@@ -16,6 +37,10 @@ export class LMStudioClient extends LLMClient {
     }
   }
 
+  /**
+   * Legacy chat method for backwards compatibility
+   * Uses the old /v1/chat/completions endpoint
+   */
   async chat(messages: LLMMessage[]): Promise<string> {
     if (!this.model) {
       throw new Error('No model selected');
@@ -43,15 +68,286 @@ export class LMStudioClient extends LLMClient {
     }
   }
 
+  /**
+   * New chat method using /api/v1/chat endpoint
+   * Supports streaming, reasoning, and response_id for conversation continuity
+   */
+  async chatV1(
+    input: string,
+    options: LMStudioChatOptions = {}
+  ): Promise<LMStudioChatResult> {
+    if (!this.model) {
+      throw new Error('No model selected');
+    }
+
+    const {
+      systemPrompt,
+      previousResponseId,
+      temperature = 0.7,
+      store = true,
+      callbacks,
+    } = options;
+
+    const requestBody: LMStudioChatRequest = {
+      model: this.model,
+      input,
+      stream: !!callbacks,
+      temperature,
+      store,
+    };
+
+    if (systemPrompt) {
+      requestBody.system_prompt = systemPrompt;
+    }
+
+    if (previousResponseId) {
+      requestBody.previous_response_id = previousResponseId;
+    }
+
+    console.log('[Vault AI] LMStudio chatV1 request:', {
+      ...requestBody,
+      input: input.slice(0, 100) + '...',
+    });
+
+    if (callbacks) {
+      return this.chatV1Streaming(requestBody, callbacks);
+    } else {
+      return this.chatV1NonStreaming(requestBody);
+    }
+  }
+
+  /**
+   * Non-streaming chat using the new API
+   */
+  private async chatV1NonStreaming(
+    requestBody: LMStudioChatRequest
+  ): Promise<LMStudioChatResult> {
+    try {
+      const response: LMStudioNewChatResponse = await this.request(
+        `${this.baseUrl}/api/v1/chat`,
+        'POST',
+        requestBody
+      );
+
+      let content = '';
+      let reasoning = '';
+
+      for (const item of response.output) {
+        if (item.type === 'message' && item.content) {
+          content += item.content;
+        } else if (item.type === 'reasoning' && item.content) {
+          reasoning += item.content;
+        }
+      }
+
+      return {
+        content,
+        reasoning: reasoning || undefined,
+        responseId: response.response_id,
+        stats: response.stats,
+      };
+    } catch (error) {
+      console.error('LM Studio chatV1 error:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Streaming chat using Server-Sent Events
+   */
+  private async chatV1Streaming(
+    requestBody: LMStudioChatRequest,
+    callbacks: LMStudioStreamCallbacks
+  ): Promise<LMStudioChatResult> {
+    const url = `${this.baseUrl}/api/v1/chat`;
+
+    console.log('[Vault AI] Starting streaming request to:', url);
+
+    try {
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'text/event-stream',
+        },
+        body: JSON.stringify(requestBody),
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP error: ${response.status}`);
+      }
+
+      if (!response.body) {
+        throw new Error('Response body is null');
+      }
+
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+
+      let content = '';
+      let reasoning = '';
+      let responseId: string | undefined;
+      let stats: LMStudioNewChatResponse['stats'] | undefined;
+      let buffer = '';
+
+      while (true) {
+        const { done, value } = await reader.read();
+
+        if (done) {
+          break;
+        }
+
+        buffer += decoder.decode(value, { stream: true });
+
+        // Process complete SSE events from buffer
+        const lines = buffer.split('\n');
+        buffer = lines.pop() || ''; // Keep incomplete line in buffer
+
+        let eventType: string | null = null;
+        let eventData: string | null = null;
+
+        for (const line of lines) {
+          if (line.startsWith('event: ')) {
+            eventType = line.slice(7).trim();
+          } else if (line.startsWith('data: ')) {
+            eventData = line.slice(6);
+
+            if (eventType && eventData) {
+              try {
+                const event: LMStudioStreamEvent = JSON.parse(eventData);
+                this.handleStreamEvent(event, callbacks, {
+                  addContent: (c) => (content += c),
+                  addReasoning: (r) => (reasoning += r),
+                  setResponseId: (id) => (responseId = id),
+                  setStats: (s) => (stats = s),
+                });
+              } catch (e) {
+                console.warn('[Vault AI] Failed to parse SSE event:', eventData, e);
+              }
+            }
+
+            eventType = null;
+            eventData = null;
+          } else if (line === '') {
+            // Empty line marks end of an event
+            eventType = null;
+            eventData = null;
+          }
+        }
+      }
+
+      return {
+        content,
+        reasoning: reasoning || undefined,
+        responseId,
+        stats,
+      };
+    } catch (error) {
+      console.error('LM Studio streaming error:', error);
+      callbacks.onError?.({
+        type: 'unknown',
+        message: error instanceof Error ? error.message : 'Unknown error',
+      });
+      throw error;
+    }
+  }
+
+  /**
+   * Handle individual stream events
+   */
+  private handleStreamEvent(
+    event: LMStudioStreamEvent,
+    callbacks: LMStudioStreamCallbacks,
+    state: {
+      addContent: (c: string) => void;
+      addReasoning: (r: string) => void;
+      setResponseId: (id: string) => void;
+      setStats: (s: LMStudioNewChatResponse['stats']) => void;
+    }
+  ): void {
+    switch (event.type) {
+      case 'message.start':
+        callbacks.onMessageStart?.();
+        break;
+
+      case 'message.delta':
+        if (event.content) {
+          state.addContent(event.content);
+          callbacks.onMessageDelta?.(event.content);
+        }
+        break;
+
+      case 'message.end':
+        callbacks.onMessageEnd?.();
+        break;
+
+      case 'reasoning.start':
+        callbacks.onReasoningStart?.();
+        break;
+
+      case 'reasoning.delta':
+        if (event.content) {
+          state.addReasoning(event.content);
+          callbacks.onReasoningDelta?.(event.content);
+        }
+        break;
+
+      case 'reasoning.end':
+        callbacks.onReasoningEnd?.();
+        break;
+
+      case 'model_load.progress':
+        if (event.progress !== undefined) {
+          callbacks.onModelLoadProgress?.(event.progress);
+        }
+        break;
+
+      case 'prompt_processing.progress':
+        if (event.progress !== undefined) {
+          callbacks.onPromptProcessingProgress?.(event.progress);
+        }
+        break;
+
+      case 'error':
+        if (event.error) {
+          callbacks.onError?.(event.error);
+        }
+        break;
+
+      case 'chat.end':
+        if (event.result) {
+          if (event.result.response_id) {
+            state.setResponseId(event.result.response_id);
+          }
+          if (event.result.stats) {
+            state.setStats(event.result.stats);
+          }
+          callbacks.onChatEnd?.(event.result);
+        }
+        break;
+    }
+  }
+
   async chatStream(
     messages: LLMMessage[],
     onToken: (token: string) => void
   ): Promise<string> {
-    // requestUrl doesn't support streaming, so we use non-streaming mode
-    // and return the full response at once
-    const response = await this.chat(messages);
-    onToken(response);
-    return response;
+    // Convert LLMMessage array to single input for the new API
+    const lastUserMessage = messages.filter((m) => m.role === 'user').pop();
+    const systemMessage = messages.find((m) => m.role === 'system');
+
+    if (!lastUserMessage) {
+      throw new Error('No user message found');
+    }
+
+    const result = await this.chatV1(lastUserMessage.content, {
+      systemPrompt: systemMessage?.content,
+      callbacks: {
+        onMessageDelta: onToken,
+      },
+    });
+
+    return result.content;
   }
 
   async isConnected(): Promise<boolean> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,6 +41,7 @@ export interface ChatMessage {
   timestamp: number;
   sources?: string[];
   searchSteps?: SearchStep[];
+  reasoning?: string;
 }
 
 export interface SearchStep {
@@ -62,6 +63,7 @@ export interface Conversation {
   contextScope: ContextScope;
   createdAt: number;
   updatedAt: number;
+  lmStudioResponseId?: string;
 }
 
 export interface ChatHistory {
@@ -228,6 +230,111 @@ export interface LMStudioChatResponse {
     completion_tokens: number;
     total_tokens: number;
   };
+}
+
+// ============================================================================
+// LMStudio New API v1 Types
+// ============================================================================
+
+export type LMStudioInputItem =
+  | { type: 'message'; content: string }
+  | { type: 'image'; data_url: string };
+
+export interface LMStudioChatRequest {
+  model: string;
+  input: string | LMStudioInputItem[];
+  system_prompt?: string;
+  stream?: boolean;
+  temperature?: number;
+  top_p?: number;
+  top_k?: number;
+  min_p?: number;
+  repeat_penalty?: number;
+  max_output_tokens?: number;
+  reasoning?: 'off' | 'low' | 'medium' | 'high' | 'on';
+  context_length?: number;
+  store?: boolean;
+  previous_response_id?: string;
+}
+
+export interface LMStudioOutputItem {
+  type: 'message' | 'tool_call' | 'reasoning' | 'invalid_tool_call';
+  content?: string;
+  tool?: string;
+  arguments?: Record<string, unknown>;
+  output?: string;
+  reason?: string;
+}
+
+export interface LMStudioChatStats {
+  input_tokens: number;
+  total_output_tokens: number;
+  reasoning_output_tokens: number;
+  tokens_per_second: number;
+  time_to_first_token_seconds: number;
+  model_load_time_seconds?: number;
+}
+
+export interface LMStudioNewChatResponse {
+  model_instance_id: string;
+  output: LMStudioOutputItem[];
+  stats: LMStudioChatStats;
+  response_id?: string;
+}
+
+// Streaming event types
+export type LMStudioStreamEventType =
+  | 'chat.start'
+  | 'model_load.start'
+  | 'model_load.progress'
+  | 'model_load.end'
+  | 'prompt_processing.start'
+  | 'prompt_processing.progress'
+  | 'prompt_processing.end'
+  | 'reasoning.start'
+  | 'reasoning.delta'
+  | 'reasoning.end'
+  | 'tool_call.start'
+  | 'tool_call.arguments'
+  | 'tool_call.success'
+  | 'tool_call.failure'
+  | 'message.start'
+  | 'message.delta'
+  | 'message.end'
+  | 'error'
+  | 'chat.end';
+
+export interface LMStudioStreamEvent {
+  type: LMStudioStreamEventType;
+  model_instance_id?: string;
+  progress?: number;
+  load_time_seconds?: number;
+  content?: string;
+  tool?: string;
+  arguments?: Record<string, unknown>;
+  output?: string;
+  reason?: string;
+  error?: {
+    type: string;
+    message: string;
+    code?: string;
+    param?: string;
+  };
+  result?: LMStudioNewChatResponse;
+}
+
+// Streaming callbacks
+export interface LMStudioStreamCallbacks {
+  onMessageDelta?: (content: string) => void;
+  onReasoningDelta?: (content: string) => void;
+  onReasoningStart?: () => void;
+  onReasoningEnd?: () => void;
+  onMessageStart?: () => void;
+  onMessageEnd?: () => void;
+  onModelLoadProgress?: (progress: number) => void;
+  onPromptProcessingProgress?: (progress: number) => void;
+  onError?: (error: { type: string; message: string }) => void;
+  onChatEnd?: (result: LMStudioNewChatResponse) => void;
 }
 
 // ============================================================================

--- a/src/ui/ChatWindowView.ts
+++ b/src/ui/ChatWindowView.ts
@@ -1,7 +1,8 @@
 import { ItemView, WorkspaceLeaf, MarkdownRenderer, Notice, TFile, setIcon, Menu } from 'obsidian';
 import type VaultAIPlugin from '../main';
-import { ChatMessage, ContextScope, SearchStep, Conversation } from '../types';
+import { ChatMessage, ContextScope, SearchStep, Conversation, LMStudioStreamCallbacks } from '../types';
 import { AgenticSearch } from '../search/AgenticSearch';
+import { LMStudioClient, LMStudioChatResult } from '../llm/LMStudioClient';
 
 export const VIEW_TYPE_CHAT_WINDOW = 'vault-ai-chat-window';
 
@@ -14,6 +15,13 @@ export class ChatWindowView extends ItemView {
   private modelDropdown: HTMLSelectElement | null = null;
   private statusEl: HTMLElement | null = null;
   private isProcessing = false;
+
+  // Streaming state
+  private streamingMessageEl: HTMLElement | null = null;
+  private streamingContentEl: HTMLElement | null = null;
+  private streamingReasoningEl: HTMLElement | null = null;
+  private streamingContent = '';
+  private streamingReasoning = '';
 
   constructor(leaf: WorkspaceLeaf, plugin: VaultAIPlugin) {
     super(leaf);
@@ -268,6 +276,14 @@ export class ChatWindowView extends ItemView {
       `vault-ai-message vault-ai-message-${message.role}`
     );
 
+    // Render reasoning/thinking first (if present and enabled)
+    if (
+      this.plugin.settings.showThinkingProcess &&
+      message.reasoning
+    ) {
+      this.renderReasoningContent(messageEl, message.reasoning);
+    }
+
     const contentEl = messageEl.createDiv('vault-ai-message-content');
 
     // Render markdown content
@@ -302,7 +318,7 @@ export class ChatWindowView extends ItemView {
       }
     }
 
-    // Render thinking process if enabled and present
+    // Render search steps thinking process if enabled and present
     if (
       this.plugin.settings.showThinkingProcess &&
       message.searchSteps &&
@@ -310,6 +326,32 @@ export class ChatWindowView extends ItemView {
     ) {
       this.renderThinkingProcess(messageEl, message.searchSteps);
     }
+  }
+
+  private renderReasoningContent(parent: HTMLElement, reasoning: string): void {
+    const reasoningEl = parent.createDiv('vault-ai-reasoning');
+
+    const header = reasoningEl.createDiv('vault-ai-reasoning-header');
+    header.createSpan({ text: 'Thinking' });
+
+    const expandIcon = header.createSpan({ text: '▶', cls: 'expand-icon' });
+    const content = reasoningEl.createDiv('vault-ai-reasoning-content');
+    content.style.display = 'none';
+
+    // Render reasoning as markdown
+    MarkdownRenderer.render(
+      this.plugin.app,
+      reasoning,
+      content,
+      '',
+      this
+    );
+
+    header.addEventListener('click', () => {
+      const isExpanded = content.style.display !== 'none';
+      content.style.display = isExpanded ? 'none' : 'block';
+      expandIcon.textContent = isExpanded ? '▶' : '▼';
+    });
   }
 
   private renderThinkingProcess(parent: HTMLElement, steps: SearchStep[]): void {
@@ -347,6 +389,112 @@ export class ChatWindowView extends ItemView {
     }
   }
 
+  // Streaming message helpers
+  private createStreamingMessage(): void {
+    if (!this.messagesEl) return;
+
+    this.streamingContent = '';
+    this.streamingReasoning = '';
+
+    this.streamingMessageEl = this.messagesEl.createDiv(
+      'vault-ai-message vault-ai-message-assistant vault-ai-message-streaming'
+    );
+
+    // Create reasoning container (hidden initially)
+    if (this.plugin.settings.showThinkingProcess) {
+      this.streamingReasoningEl = this.streamingMessageEl.createDiv('vault-ai-reasoning');
+      const reasoningHeader = this.streamingReasoningEl.createDiv('vault-ai-reasoning-header');
+      reasoningHeader.createSpan({ text: 'Thinking...' });
+      const expandIcon = reasoningHeader.createSpan({ text: '▼', cls: 'expand-icon' });
+      const reasoningContent = this.streamingReasoningEl.createDiv('vault-ai-reasoning-content');
+      reasoningContent.style.display = 'block'; // Show while streaming
+
+      reasoningHeader.addEventListener('click', () => {
+        const isExpanded = reasoningContent.style.display !== 'none';
+        reasoningContent.style.display = isExpanded ? 'none' : 'block';
+        expandIcon.textContent = isExpanded ? '▶' : '▼';
+      });
+
+      // Hide until we get reasoning content
+      this.streamingReasoningEl.style.display = 'none';
+    }
+
+    this.streamingContentEl = this.streamingMessageEl.createDiv('vault-ai-message-content');
+    this.streamingContentEl.createSpan({ text: '...', cls: 'vault-ai-typing-indicator' });
+
+    this.messagesEl.scrollTop = this.messagesEl.scrollHeight;
+  }
+
+  private updateStreamingContent(content: string): void {
+    if (!this.streamingContentEl) return;
+
+    this.streamingContent += content;
+    this.streamingContentEl.empty();
+
+    // Re-render markdown
+    MarkdownRenderer.render(
+      this.plugin.app,
+      this.streamingContent,
+      this.streamingContentEl,
+      '',
+      this
+    );
+
+    if (this.messagesEl) {
+      this.messagesEl.scrollTop = this.messagesEl.scrollHeight;
+    }
+  }
+
+  private updateStreamingReasoning(content: string): void {
+    if (!this.streamingReasoningEl || !this.plugin.settings.showThinkingProcess) return;
+
+    this.streamingReasoning += content;
+
+    // Show reasoning container
+    this.streamingReasoningEl.style.display = 'block';
+
+    const reasoningContent = this.streamingReasoningEl.querySelector('.vault-ai-reasoning-content');
+    if (reasoningContent) {
+      reasoningContent.empty();
+      MarkdownRenderer.render(
+        this.plugin.app,
+        this.streamingReasoning,
+        reasoningContent as HTMLElement,
+        '',
+        this
+      );
+    }
+
+    if (this.messagesEl) {
+      this.messagesEl.scrollTop = this.messagesEl.scrollHeight;
+    }
+  }
+
+  private finalizeStreamingMessage(): void {
+    if (this.streamingMessageEl) {
+      this.streamingMessageEl.removeClass('vault-ai-message-streaming');
+
+      // Update reasoning header text
+      if (this.streamingReasoningEl) {
+        const header = this.streamingReasoningEl.querySelector('.vault-ai-reasoning-header span:first-child');
+        if (header) {
+          header.textContent = 'Thinking';
+        }
+        // Collapse reasoning after streaming completes
+        const reasoningContent = this.streamingReasoningEl.querySelector('.vault-ai-reasoning-content') as HTMLElement;
+        const expandIcon = this.streamingReasoningEl.querySelector('.expand-icon');
+        if (reasoningContent && expandIcon) {
+          reasoningContent.style.display = 'none';
+          expandIcon.textContent = '▶';
+        }
+      }
+    }
+
+    this.streamingMessageEl = null;
+    this.streamingContentEl = null;
+    this.streamingReasoningEl = null;
+  }
+
   async sendMessage(): Promise<void> {
     if (!this.inputEl || this.isProcessing || !this.conversationId) return;
 
@@ -378,10 +526,126 @@ export class ChatWindowView extends ItemView {
     // Update displayed title if this is the first message
     this.updateDisplayedTitle();
 
-    // Process with agentic search
+    // Process message
     this.isProcessing = true;
     this.plugin.setConnectionStatus('thinking');
 
+    // Check if using LMStudio with new API
+    const isLMStudio = this.plugin.settings.serverType === 'lmstudio';
+
+    if (isLMStudio) {
+      await this.sendMessageLMStudio(userMessage);
+    } else {
+      await this.sendMessageLegacy(userMessage);
+    }
+  }
+
+  private async sendMessageLMStudio(userMessage: string): Promise<void> {
+    const lmClient = this.plugin.llmClient as LMStudioClient;
+
+    // Get the previous response ID for conversation continuity
+    const previousResponseId = this.plugin.chatHistory.getLMStudioResponseId(
+      this.conversationId!
+    );
+
+    // Create streaming message UI
+    this.createStreamingMessage();
+
+    const systemPrompt = `You are a helpful assistant that answers questions based on the user's personal notes.
+Be concise and helpful. When answering:
+- Directly answer the question based on the provided notes
+- Mention which notes contain the relevant information
+- If the notes don't contain enough information to fully answer, say so
+- Do not make up information that isn't in the notes`;
+
+    // Build context from vault search
+    const conversation = this.getConversation();
+    const scope = conversation?.contextScope || this.plugin.settings.defaultContextScope;
+
+    // Get vault context
+    const search = new AgenticSearch(this.plugin);
+    const searchResult = await search.search(userMessage, scope);
+
+    // Build input with context
+    let input = userMessage;
+    if (searchResult.sources.length > 0) {
+      input = `Based on the following notes from my vault, please answer this question: "${userMessage}"
+
+--- NOTES FROM VAULT ---
+
+${searchResult.sources.map((s) => `Source: ${s}`).join('\n')}
+
+--- END OF NOTES ---
+
+Please answer the question based on the information found.`;
+    }
+
+    try {
+      const result = await lmClient.chatV1(input, {
+        systemPrompt,
+        previousResponseId,
+        store: true,
+        callbacks: {
+          onMessageDelta: (content) => {
+            this.updateStreamingContent(content);
+          },
+          onReasoningDelta: (content) => {
+            this.updateStreamingReasoning(content);
+          },
+          onReasoningStart: () => {
+            console.log('[Vault AI] Reasoning started');
+          },
+          onReasoningEnd: () => {
+            console.log('[Vault AI] Reasoning ended');
+          },
+          onError: (error) => {
+            console.error('[Vault AI] Stream error:', error);
+            new Notice(`Error: ${error.message}`);
+          },
+        },
+      });
+
+      // Finalize the streaming message
+      this.finalizeStreamingMessage();
+
+      // Update the LMStudio response ID for conversation continuity
+      if (result.responseId) {
+        await this.plugin.chatHistory.updateLMStudioResponseId(
+          this.conversationId!,
+          result.responseId
+        );
+      }
+
+      // Add assistant message with results
+      const assistantMsg: ChatMessage = {
+        role: 'assistant',
+        content: result.content,
+        timestamp: Date.now(),
+        sources: searchResult.sources,
+        searchSteps: searchResult.steps,
+        reasoning: result.reasoning,
+      };
+
+      await this.plugin.chatHistory.addMessage(this.conversationId!, assistantMsg);
+    } catch (error) {
+      console.error('LMStudio chat error:', error);
+      this.finalizeStreamingMessage();
+
+      const errorMsg: ChatMessage = {
+        role: 'assistant',
+        content: `I encountered an error: ${error}. Please try again.`,
+        timestamp: Date.now(),
+      };
+
+      await this.plugin.chatHistory.addMessage(this.conversationId!, errorMsg);
+    } finally {
+      this.isProcessing = false;
+      this.plugin.setConnectionStatus('ready');
+      this.renderMessages();
+    }
+  }
+
+  private async sendMessageLegacy(userMessage: string): Promise<void> {
     try {
       const conversation = this.getConversation();
       const scope = conversation?.contextScope || this.plugin.settings.defaultContextScope;
@@ -398,7 +662,7 @@ export class ChatWindowView extends ItemView {
         searchSteps: result.steps,
       };
 
-      await this.plugin.chatHistory.addMessage(this.conversationId, assistantMsg);
+      await this.plugin.chatHistory.addMessage(this.conversationId!, assistantMsg);
     } catch (error) {
       console.error('Chat error:', error);
 
@@ -408,7 +672,7 @@ export class ChatWindowView extends ItemView {
         timestamp: Date.now(),
       };
 
-      await this.plugin.chatHistory.addMessage(this.conversationId, errorMsg);
+      await this.plugin.chatHistory.addMessage(this.conversationId!, errorMsg);
     } finally {
       this.isProcessing = false;
       this.plugin.setConnectionStatus('ready');

--- a/styles.css
+++ b/styles.css
@@ -1234,3 +1234,132 @@
   padding: 12px 16px;
   border-top: 1px solid var(--background-modifier-border);
 }
+
+/* ============================================================================
+   LLM Reasoning/Thinking Display
+   ============================================================================ */
+
+.vault-ai-message .vault-ai-reasoning {
+  margin: 0 0 12px 0;
+  font-size: 12px;
+  border: 1px solid var(--background-modifier-border);
+  border-radius: 6px;
+  background: linear-gradient(135deg, rgba(139, 92, 246, 0.05) 0%, rgba(59, 130, 246, 0.05) 100%);
+  overflow: hidden;
+}
+
+.vault-ai-message .vault-ai-reasoning-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  cursor: pointer;
+  color: var(--text-muted);
+  background: rgba(139, 92, 246, 0.08);
+  border-bottom: 1px solid transparent;
+  transition: all 0.15s ease;
+}
+
+.vault-ai-message .vault-ai-reasoning-header:hover {
+  background: rgba(139, 92, 246, 0.12);
+  color: var(--text-normal);
+}
+
+.vault-ai-message .vault-ai-reasoning-header span:first-child {
+  font-weight: 500;
+  color: rgb(139, 92, 246);
+}
+
+.vault-ai-message .vault-ai-reasoning-header span:first-child::before {
+  content: "💭 ";
+}
+
+.vault-ai-message .vault-ai-reasoning-content {
+  padding: 12px;
+  color: var(--text-muted);
+  line-height: 1.6;
+  font-style: italic;
+  border-top: 1px solid var(--background-modifier-border);
+}
+
+.vault-ai-message .vault-ai-reasoning-content p {
+  margin: 0 0 8px 0;
+}
+
+.vault-ai-message .vault-ai-reasoning-content p:last-child {
+  margin-bottom: 0;
+}
+
+/* ============================================================================
+   Streaming Message Styles
+   ============================================================================ */
+
+.vault-ai-message-streaming {
+  position: relative;
+}
+
+.vault-ai-message-streaming::after {
+  content: "";
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: linear-gradient(90deg,
+    var(--interactive-accent) 0%,
+    rgba(139, 92, 246, 0.8) 50%,
+    var(--interactive-accent) 100%);
+  background-size: 200% 100%;
+  animation: streaming-gradient 2s linear infinite;
+}
+
+@keyframes streaming-gradient {
+  0% { background-position: 100% 0; }
+  100% { background-position: -100% 0; }
+}
+
+.vault-ai-typing-indicator {
+  display: inline-block;
+  animation: typing-blink 1s ease-in-out infinite;
+  color: var(--text-muted);
+}
+
+@keyframes typing-blink {
+  0%, 100% { opacity: 0.3; }
+  50% { opacity: 1; }
+}
+
+/* Streaming reasoning - expanded by default during streaming */
+.vault-ai-message-streaming .vault-ai-reasoning {
+  border-color: rgba(139, 92, 246, 0.3);
+}
+
+.vault-ai-message-streaming .vault-ai-reasoning-header {
+  background: rgba(139, 92, 246, 0.15);
+}
+
+.vault-ai-message-streaming .vault-ai-reasoning-header span:first-child {
+  animation: thinking-pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes thinking-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}
+
+/* ============================================================================
+   Controls Container Updates
+   ============================================================================ */
+
+.vault-ai-chat-area .vault-ai-controls-container {
+  padding: 8px 12px;
+  margin-bottom: 0;
+  border-bottom: 1px solid var(--background-modifier-border);
+  background: var(--background-secondary);
+}
+
+.vault-ai-chat-window-container .vault-ai-controls-container {
+  padding: 8px 16px;
+  border-bottom: 1px solid var(--background-modifier-border);
+  background: var(--background-secondary);
+}


### PR DESCRIPTION
- Add new /api/v1/chat endpoint support with streaming via SSE
- Implement conversation continuity using previous_response_id
- Display model reasoning/thinking content in collapsible UI
- Add real-time streaming message updates with visual indicators
- Store LMStudio response_id in conversations for history sourcing
- Add CSS styles for reasoning display and streaming animations

https://claude.ai/code/session_01WRmYmj3vihA6d8oxdhhqYZ