### PR TITLE
Fix processing state not resetting on message send errors

### DIFF
--- a/src/ui/ChatTab.ts
+++ b/src/ui/ChatTab.ts
@@ -951,6 +951,8 @@ export class ChatTab {
 
       await this.plugin.chatHistory.addMessage(this.currentConversationId!, errorMsg);
     } finally {
+      this.isProcessing = false;
+      this.view.setConnectionStatus('ready');
       this.renderMessages();
     }
   }
@@ -1050,6 +1052,8 @@ Please answer the question based on the information found.`;
 
       await this.plugin.chatHistory.addMessage(this.currentConversationId!, errorMsg);
     } finally {
+      this.isProcessing = false;
+      this.view.setConnectionStatus('ready');
       this.renderMessages();
     }
   }

--- a/src/ui/ChatWindowView.ts
+++ b/src/ui/ChatWindowView.ts
@@ -683,17 +683,25 @@ export class ChatWindowView extends ItemView {
     // Update displayed title if this is the first message
     this.updateDisplayedTitle();
 
-    // Process message
+    // Process message - wrap in try/finally to ensure state is always reset
     this.isProcessing = true;
     this.plugin.setConnectionStatus('thinking');
 
-    // Check if using LMStudio with new API
-    const isLMStudio = this.plugin.settings.serverType === 'lmstudio';
+    try {
+      // Check if using LMStudio with new API
+      const isLMStudio = this.plugin.settings.serverType === 'lmstudio';
 
-    if (isLMStudio) {
-      await this.sendMessageLMStudio(userMessage);
-    } else {
-      await this.sendMessageLegacy(userMessage);
+      if (isLMStudio) {
+        await this.sendMessageLMStudio(userMessage);
+      } else {
+        await this.sendMessageLegacy(userMessage);
+      }
+    } catch (error) {
+      console.error('Error in sendMessage:', error);
+      new Notice(`Error sending message: ${error}`);
+    } finally {
+      this.isProcessing = false;
+      this.plugin.setConnectionStatus('ready');
     }
   }
 


### PR DESCRIPTION
## Summary
This PR fixes a bug where the chat processing state (`isProcessing`) and connection status were not being properly reset when errors occurred during message sending. This could leave the UI in a "thinking" state indefinitely, preventing users from sending new messages.

## Key Changes
- **ChatWindowView.ts**: Wrapped the message sending logic in a try/catch/finally block to ensure `isProcessing` is always reset to `false` and connection status is set to `'ready'`, even when errors occur
- **ChatTab.ts**: Added explicit state reset (`isProcessing = false` and `setConnectionStatus('ready')`) in the finally blocks of two message processing methods to guarantee cleanup

## Implementation Details
- The try/catch/finally pattern ensures that regardless of whether the message send succeeds or fails, the UI state is properly reset
- Error messages are logged to console and displayed to the user via a Notice
- This prevents the UI from getting stuck in a "thinking" state when network errors, API errors, or other exceptions occur during message processing

https://claude.ai/code/session_01P9zMNzuL5VLTUUUJcyphv3