### PR TITLE
Add active note context to agent prompts and chat

### DIFF
--- a/src/agent/ChatAgent.ts
+++ b/src/agent/ChatAgent.ts
@@ -258,13 +258,23 @@ export class ChatAgent {
     };
 
     const currentFile = this.app.workspace.getActiveFile();
-    const currentPath = currentFile?.path || 'No file currently open';
+    const currentPath = currentFile?.path || null;
+
+    let contextInfo = '';
+    if (currentPath) {
+      contextInfo = `Current context:
+- Currently open note: "${currentPath}"
+  (You can use read_note with this path if you need the note's content for context)
+- Search scope: ${scopeDescription[scope]}`;
+    } else {
+      contextInfo = `Current context:
+- No note currently open
+- Search scope: ${scopeDescription[scope]}`;
+    }
 
     return `User request: "${query}"
 
-Current context:
-- Current file: ${currentPath}
-- Search scope: ${scopeDescription[scope]}
+${contextInfo}
 
 Please help the user with their request. Use the available tools to search, read, create, or modify notes as needed. When done, use the final_answer tool to provide your response.`;
   }

--- a/src/prompts/agent.ts
+++ b/src/prompts/agent.ts
@@ -147,6 +147,15 @@ Provide your final response to the user.
 3. You can chain multiple tools to accomplish complex tasks
 4. Always end with the final_answer tool to provide your response
 
+## Active Note Context
+
+The user's currently open note will be provided with each request. This is the note they are actively viewing/editing. Consider this context when responding:
+
+- If the user's request seems related to the current note (e.g., "summarize this", "format this note", "what does this mean"), it likely refers to the currently open note
+- You can use the read_note tool to read the full content of the current note if you need more context
+- The current note path is always provided in the user's request - use it to understand their context
+- When creating related content, consider linking back to or organizing near the current note
+
 ## Guidelines
 
 ### For Information Requests:


### PR DESCRIPTION
## Summary
This PR enhances the agent and chat systems to be aware of the user's currently open note, allowing for more contextual and relevant responses when users reference "this note" or their current context.

## Key Changes

- **ChatAgent.ts**: Modified the search prompt to include information about the currently open note. The prompt now explicitly mentions that users can use `read_note` to access the current note's content if needed, with clearer formatting that distinguishes between cases where a note is open vs. not open.

- **agent.ts**: Added a new "Active Note Context" section to the system prompt that educates the agent about how to interpret user requests in relation to their currently open note, including guidance on when to use the `read_note` tool and how to organize related content.

- **ChatTab.ts**: 
  - Added `getCurrentNoteContext()` helper method to extract and format the currently open note information
  - Updated `sendMessageWithMCP()` to append current note context to the system prompt
  - Updated the vault search flow to include current note context in both the system prompt and user input, ensuring the agent understands which note the user is actively viewing

## Implementation Details

- The currently open note path is now passed to the agent in multiple ways: in the search prompt, in the system prompt, and in the user input context
- When no note is open, the system gracefully handles this by providing appropriate context messages
- The implementation maintains backward compatibility while adding this new contextual awareness
- The agent is explicitly instructed that the current note path is provided to help understand user context and can be used with the `read_note` tool for full content access

https://claude.ai/code/session_01GHWxPviKn8PqkVmt95s4NK