### PR TITLE
Add reasoning level control to LM Studio chat interface

### DIFF
--- a/src/llm/LMStudioClient.ts
+++ b/src/llm/LMStudioClient.ts
@@ -15,6 +15,7 @@ export interface LMStudioChatOptions {
   store?: boolean;
   callbacks?: LMStudioStreamCallbacks;
   mcpServerUrl?: string;
+  reasoning?: 'off' | 'low' | 'medium' | 'high' | 'on';
 }
 
 export interface LMStudioChatResult {
@@ -98,6 +99,7 @@ export class LMStudioClient extends LLMClient {
       store = true,
       callbacks,
       mcpServerUrl,
+      reasoning,
     } = options;
 
     const requestBody: LMStudioChatRequest = {
@@ -114,6 +116,11 @@ export class LMStudioClient extends LLMClient {
 
     if (previousResponseId) {
       requestBody.previous_response_id = previousResponseId;
+    }
+
+    // Add reasoning setting if provided
+    if (reasoning) {
+      requestBody.reasoning = reasoning;
     }
 
     // Add MCP integration if provided

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,8 @@
 export type ContextScope = 'current' | 'linked' | 'folder' | 'vault';
 export type ConnectionStatus = 'ready' | 'thinking' | 'offline';
 
+export type ReasoningLevel = 'auto' | 'off' | 'low' | 'medium' | 'high' | 'on';
+
 export interface VaultAISettings {
   serverUrl: string;
   selectedModel: string;
@@ -12,6 +14,7 @@ export interface VaultAISettings {
   mcpEnabled: boolean;
   mcpPort: number;
   systemPrompt: string;
+  reasoning: ReasoningLevel;
 }
 
 export const DEFAULT_SYSTEM_PROMPT = `You are a helpful AI assistant with access to the user's Obsidian vault through MCP tools.
@@ -30,6 +33,7 @@ export const DEFAULT_SETTINGS: VaultAISettings = {
   mcpEnabled: true,
   mcpPort: 3456,
   systemPrompt: DEFAULT_SYSTEM_PROMPT,
+  reasoning: 'auto',
 };
 
 // ============================================================================

--- a/src/ui/ChatWindowView.ts
+++ b/src/ui/ChatWindowView.ts
@@ -1,6 +1,6 @@
 import { ItemView, WorkspaceLeaf, MarkdownRenderer, Notice, TFile, setIcon, Menu, setTooltip } from 'obsidian';
 import type VaultAIPlugin from '../main';
-import { ChatMessage, ContextScope, SearchStep, Conversation, LMStudioStreamCallbacks, AgentStep } from '../types';
+import { ChatMessage, ContextScope, SearchStep, Conversation, LMStudioStreamCallbacks, AgentStep, ReasoningLevel } from '../types';
 import { AgenticSearch } from '../search/AgenticSearch';
 import { LMStudioClient, LMStudioChatResult } from '../llm/LMStudioClient';
 import { ChatAgent } from '../agent/ChatAgent';
@@ -14,6 +14,7 @@ export class ChatWindowView extends ItemView {
   private inputEl: HTMLTextAreaElement | null = null;
   private scopeDropdown: HTMLSelectElement | null = null;
   private modelDropdown: HTMLSelectElement | null = null;
+  private reasoningDropdown: HTMLSelectElement | null = null;
   private statusEl: HTMLElement | null = null;
   private isProcessing = false;
 
@@ -110,6 +111,24 @@ export class ChatWindowView extends ItemView {
       const model = this.modelDropdown?.value;
       if (model) {
         await this.plugin.setSelectedModel(model);
+      }
+    });
+
+    // Reasoning selector
+    const reasoningContainer = controlsContainer.createDiv('vault-ai-reasoning-container');
+    reasoningContainer.createSpan({ text: 'Reasoning: ' });
+
+    this.reasoningDropdown = reasoningContainer.createEl('select', {
+      cls: 'vault-ai-reasoning-dropdown',
+    });
+
+    this.populateReasoningDropdown();
+
+    this.reasoningDropdown.addEventListener('change', async () => {
+      const reasoning = this.reasoningDropdown?.value as ReasoningLevel;
+      if (reasoning) {
+        this.plugin.settings.reasoning = reasoning;
+        await this.plugin.saveSettings();
       }
     });
 
@@ -241,6 +260,35 @@ export class ChatWindowView extends ItemView {
 
   refreshModelDropdown(): void {
     this.populateModelDropdown();
+  }
+
+  private populateReasoningDropdown(): void {
+    if (!this.reasoningDropdown) return;
+
+    this.reasoningDropdown.empty();
+
+    const reasoningOptions: { value: ReasoningLevel; label: string }[] = [
+      { value: 'auto', label: 'Auto' },
+      { value: 'off', label: 'Off' },
+      { value: 'low', label: 'Low' },
+      { value: 'medium', label: 'Medium' },
+      { value: 'high', label: 'High' },
+      { value: 'on', label: 'On' },
+    ];
+
+    for (const option of reasoningOptions) {
+      const optionEl = this.reasoningDropdown.createEl('option', {
+        text: option.label,
+        value: option.value,
+      });
+      if (option.value === this.plugin.settings.reasoning) {
+        optionEl.selected = true;
+      }
+    }
+  }
+
+  refreshReasoningDropdown(): void {
+    this.populateReasoningDropdown();
   }
 
   private renderMessages(): void {
@@ -741,11 +789,17 @@ ${searchResult.sources.map((s) => `Source: ${s}`).join('\n')}
 Please answer the question based on the information found.`;
     }
 
+    // Get reasoning setting (only pass if not 'auto')
+    const reasoning = this.plugin.settings.reasoning !== 'auto'
+      ? this.plugin.settings.reasoning as 'off' | 'low' | 'medium' | 'high' | 'on'
+      : undefined;
+
     try {
       const result = await lmClient.chatV1(input, {
         systemPrompt,
         previousResponseId,
         store: true,
+        reasoning,
         callbacks: {
           onMessageDelta: (content) => {
             this.updateStreamingContent(content);

--- a/styles.css
+++ b/styles.css
@@ -365,7 +365,8 @@
 }
 
 .vault-ai-scope-container,
-.vault-ai-model-container {
+.vault-ai-model-container,
+.vault-ai-reasoning-container {
   display: flex;
   align-items: center;
   gap: var(--vai-space-2);
@@ -374,7 +375,8 @@
 }
 
 .vault-ai-scope-dropdown,
-.vault-ai-model-dropdown {
+.vault-ai-model-dropdown,
+.vault-ai-reasoning-dropdown {
   padding: 6px 10px;
   border-radius: var(--vai-radius-sm);
   border: 1px solid var(--background-modifier-border);
@@ -390,8 +392,14 @@
   max-width: 220px;
 }
 
+.vault-ai-reasoning-dropdown {
+  min-width: 80px;
+  max-width: 120px;
+}
+
 .vault-ai-scope-dropdown:focus,
-.vault-ai-model-dropdown:focus {
+.vault-ai-model-dropdown:focus,
+.vault-ai-reasoning-dropdown:focus {
   outline: none;
   border-color: var(--interactive-accent);
   box-shadow: 0 0 0 3px var(--vai-accent-soft);


### PR DESCRIPTION
## Summary
This PR adds support for configurable reasoning levels in the LM Studio chat interface, allowing users to control the model's reasoning behavior through a new dropdown selector in both the sidebar chat and chat window views.

## Key Changes
- **Type definitions**: Added `ReasoningLevel` type ('auto' | 'off' | 'low' | 'medium' | 'high' | 'on') to `types.ts` and added `reasoning` field to `VaultAISettings` with default value of 'auto'
- **LM Studio client**: Extended `LMStudioChatOptions` interface to accept reasoning parameter and pass it through to the API request body
- **Chat UI components**: 
  - Added reasoning dropdown selector to both `ChatTab` and `ChatWindowView` components
  - Implemented `populateReasoningDropdown()` and `refreshReasoningDropdown()` methods in both views
  - Integrated reasoning setting into chat message sending logic (only passes to API if not 'auto')
- **Styling**: Added CSS rules for `.vault-ai-reasoning-container` and `.vault-ai-reasoning-dropdown` with appropriate sizing and focus states

## Implementation Details
- The reasoning setting is stored in plugin settings and persists across sessions
- When reasoning is set to 'auto', it's not passed to the API (allowing server-side defaults)
- For all other values ('off', 'low', 'medium', 'high', 'on'), the setting is explicitly passed to both `chatWithMCP()` and `chatV1()` API calls
- The dropdown is consistently styled with other control dropdowns (scope, model) and maintains the same interaction patterns

https://claude.ai/code/session_01HJcAhktPWE8fVMDoRKJD2P