### PR TITLE
Handle LM Studio stream errors and prediction history bugs

### DIFF
--- a/src/ui/ChatTab.ts
+++ b/src/ui/ChatTab.ts
@@ -992,6 +992,14 @@ If the user's request relates to "this note" or seems to reference their current
       console.error('MCP chat error:', error);
       this.finalizeStreamingMessage();
 
+      // Check if this is a prediction history error (LM Studio bug)
+      const errorStr = String(error);
+      if (errorStr.includes('shard') || errorStr.includes('prediction history') || errorStr.includes('previous_response')) {
+        console.warn('[Vault AI] Prediction history error detected, clearing response ID');
+        await this.plugin.chatHistory.updateLMStudioResponseId(this.currentConversationId!, undefined as any);
+        new Notice('LM Studio conversation history error. The conversation has been reset - please try again.');
+      }
+
       const errorMsg: ChatMessage = {
         role: 'assistant',
         content: `I encountered an error: ${error}. Please try again.`,
@@ -1110,6 +1118,14 @@ Please answer the question based on the information found.`;
     } catch (error) {
       console.error('LMStudio chat error:', error);
       this.finalizeStreamingMessage();
+
+      // Check if this is a prediction history error (LM Studio bug)
+      const errorStr = String(error);
+      if (errorStr.includes('shard') || errorStr.includes('prediction history') || errorStr.includes('previous_response')) {
+        console.warn('[Vault AI] Prediction history error detected, clearing response ID');
+        await this.plugin.chatHistory.updateLMStudioResponseId(this.currentConversationId!, undefined as any);
+        new Notice('LM Studio conversation history error. The conversation has been reset - please try again.');
+      }
 
       const errorMsg: ChatMessage = {
         role: 'assistant',

--- a/src/ui/ChatWindowView.ts
+++ b/src/ui/ChatWindowView.ts
@@ -846,6 +846,14 @@ Please answer the question based on the information found.`;
       console.error('LMStudio chat error:', error);
       this.finalizeStreamingMessage();
 
+      // Check if this is a prediction history error (LM Studio bug)
+      const errorStr = String(error);
+      if (errorStr.includes('shard') || errorStr.includes('prediction history') || errorStr.includes('previous_response')) {
+        console.warn('[Vault AI] Prediction history error detected, clearing response ID');
+        await this.plugin.chatHistory.updateLMStudioResponseId(this.conversationId!, undefined as any);
+        new Notice('LM Studio conversation history error. The conversation has been reset - please try again.');
+      }
+
       const errorMsg: ChatMessage = {
         role: 'assistant',
         content: `I encountered an error: ${error}. Please try again.`,


### PR DESCRIPTION
## Summary
This PR improves error handling for LM Studio integration by properly capturing and propagating stream errors, and adds detection/recovery for a known LM Studio prediction history bug that causes shard-related failures.

## Key Changes

- **LMStudioClient.ts**: Enhanced stream error handling
  - Added `streamError` state variable to capture errors from the SSE stream
  - Added `setError` callback to the event processing state object
  - Implemented stream loop break when an error is received
  - Throw captured error after stream completes so it's properly handled by callers
  - Handle 'error' event type by calling `setError` to trigger stream termination

- **ChatTab.ts, ChatWindowView.ts**: Added prediction history error recovery
  - Detect LM Studio prediction history errors by checking error messages for keywords: 'shard', 'prediction history', 'previous_response'
  - Clear the stored LM Studio response ID when this error is detected
  - Display user-friendly notice explaining the conversation was reset
  - Applied to both MCP and LMStudio chat error handlers

## Implementation Details

The stream error handling ensures that when LM Studio sends an error event during streaming, the client:
1. Captures the error via the new `setError` callback
2. Breaks out of the read loop immediately
3. Throws the error so upstream error handlers can process it

The prediction history error recovery addresses a known LM Studio issue where conversation state becomes corrupted. By detecting and clearing the response ID, subsequent requests start fresh and avoid the corrupted state.

https://claude.ai/code/session_01AwvCzutX3MktxUgBTvdZnA