### PR TITLE
fix: add model load settings to modal and auto-load on message send

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,8 @@ export interface VaultAISettings {
   mcpPort: number;
   systemPrompt: string;
   reasoning: ReasoningLevel;
+  modelContextLength: number;
+  modelFlashAttention: boolean;
 }
 
 export const DEFAULT_SYSTEM_PROMPT = `You are a helpful AI assistant with access to the user's Obsidian vault through MCP tools.
@@ -34,6 +36,8 @@ export const DEFAULT_SETTINGS: VaultAISettings = {
   mcpPort: 3456,
   systemPrompt: DEFAULT_SYSTEM_PROMPT,
   reasoning: 'auto',
+  modelContextLength: 16384,
+  modelFlashAttention: true,
 };
 
 // ============================================================================

--- a/styles.css
+++ b/styles.css
@@ -2432,6 +2432,87 @@
   font-weight: 500;
 }
 
+/* Model Settings Section */
+.vault-ai-model-settings {
+  margin-bottom: var(--vai-space-4);
+  padding: var(--vai-space-4);
+  background: var(--background-secondary);
+  border: 1px solid var(--background-modifier-border);
+  border-radius: var(--vai-radius-md);
+}
+
+.vault-ai-model-settings-title {
+  margin: 0 0 var(--vai-space-3) 0;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.vault-ai-model-setting-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--vai-space-2) 0;
+  gap: var(--vai-space-3);
+}
+
+.vault-ai-model-setting-row + .vault-ai-model-setting-row {
+  border-top: 1px solid var(--background-modifier-border);
+}
+
+.vault-ai-model-setting-label {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-normal);
+  min-width: 120px;
+  flex-shrink: 0;
+}
+
+.vault-ai-model-setting-input {
+  display: flex;
+  align-items: center;
+  gap: var(--vai-space-2);
+  flex: 1;
+  justify-content: flex-end;
+}
+
+.vault-ai-model-ctx-input {
+  width: 100px;
+  padding: var(--vai-space-2) var(--vai-space-3);
+  border: 1px solid var(--background-modifier-border);
+  border-radius: var(--vai-radius-sm);
+  background: var(--background-primary);
+  color: var(--text-normal);
+  font-size: 13px;
+  font-family: var(--font-monospace);
+  text-align: right;
+  transition: all var(--vai-timing-fast) var(--vai-easing);
+}
+
+.vault-ai-model-ctx-input:focus {
+  outline: none;
+  border-color: var(--interactive-accent);
+  box-shadow: 0 0 0 3px var(--vai-accent-soft);
+}
+
+.vault-ai-model-setting-unit {
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.vault-ai-model-flash-toggle {
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.vault-ai-model-setting-desc {
+  font-size: 11px;
+  color: var(--text-muted);
+  line-height: 1.4;
+}
+
 /* Model list scrollbar */
 .vault-ai-model-list::-webkit-scrollbar {
   width: 6px;


### PR DESCRIPTION
The manage models modal now displays a Load Settings section with configurable context_length (default 16384) and flash_attention (default true). Settings are persisted and used when loading models both from the modal and automatically before sending messages.

When sending a message, the plugin ensures the selected model is loaded, automatically unloading any other loaded LLM models first. This guarantees only one model is loaded at a time.

Changes:
- Add modelContextLength and modelFlashAttention to VaultAISettings
- Add Load Settings UI (context length input, flash attention toggle) to modal
- Pass load options (context_length, flash_attention, echo_load_config) to API
- Add ensureModelLoaded() for auto unload/load before message send
- Show max context length and flash attention status in model details

https://claude.ai/code/session_01GrCLGcVnygXpsS4Hvoi5kx