### PR TITLE
Preserve partial streaming content on chat errors

### DIFF
--- a/src/ui/ChatTab.ts
+++ b/src/ui/ChatTab.ts
@@ -1009,23 +1009,51 @@ If the user's request relates to "this note" or seems to reference their current
       await this.plugin.chatHistory.addMessage(this.currentConversationId!, assistantMsg);
     } catch (error) {
       console.error('MCP chat error:', error);
+
+      // Capture any content that was streamed before the error
+      const partialContent = this.streamingContent || '';
+      const partialReasoning = this.streamingReasoning || '';
+
       this.finalizeStreamingMessage();
 
       // Check if this is a prediction history error (LM Studio bug)
       const errorStr = String(error);
-      if (errorStr.includes('shard') || errorStr.includes('prediction history') || errorStr.includes('previous_response')) {
+      const isPredictionHistoryError = errorStr.includes('shard') || errorStr.includes('prediction history') || errorStr.includes('previous_response');
+
+      if (isPredictionHistoryError) {
         console.warn('[Vault AI] Prediction history error detected, clearing response ID');
         await this.plugin.chatHistory.updateLMStudioResponseId(this.currentConversationId!, undefined as any);
-        new Notice('LM Studio conversation history error. The conversation has been reset - please try again.');
       }
 
-      const errorMsg: ChatMessage = {
-        role: 'assistant',
-        content: `I encountered an error: ${error}. Please try again.`,
-        timestamp: Date.now(),
-      };
+      // If we have partial content, save it instead of just the error
+      if (partialContent.trim()) {
+        const assistantMsg: ChatMessage = {
+          role: 'assistant',
+          content: partialContent,
+          timestamp: Date.now(),
+          reasoning: partialReasoning || undefined,
+        };
+        await this.plugin.chatHistory.addMessage(this.currentConversationId!, assistantMsg);
 
-      await this.plugin.chatHistory.addMessage(this.currentConversationId!, errorMsg);
+        // Show a notice about the error but don't lose the content
+        if (isPredictionHistoryError) {
+          new Notice('LM Studio had an internal error, but the response was saved.');
+        } else {
+          new Notice(`Stream ended with error, but partial response was saved.`);
+        }
+      } else {
+        // No content was streamed, save error message
+        const errorMsg: ChatMessage = {
+          role: 'assistant',
+          content: `I encountered an error: ${error}. Please try again.`,
+          timestamp: Date.now(),
+        };
+        await this.plugin.chatHistory.addMessage(this.currentConversationId!, errorMsg);
+
+        if (isPredictionHistoryError) {
+          new Notice('LM Studio conversation history error. The conversation has been reset - please try again.');
+        }
+      }
     } finally {
       this.isProcessing = false;
       this.view.setConnectionStatus('ready');
@@ -1136,23 +1164,53 @@ Please answer the question based on the information found.`;
       await this.plugin.chatHistory.addMessage(this.currentConversationId!, assistantMsg);
     } catch (error) {
       console.error('LMStudio chat error:', error);
+
+      // Capture any content that was streamed before the error
+      const partialContent = this.streamingContent || '';
+      const partialReasoning = this.streamingReasoning || '';
+
       this.finalizeStreamingMessage();
 
       // Check if this is a prediction history error (LM Studio bug)
       const errorStr = String(error);
-      if (errorStr.includes('shard') || errorStr.includes('prediction history') || errorStr.includes('previous_response')) {
+      const isPredictionHistoryError = errorStr.includes('shard') || errorStr.includes('prediction history') || errorStr.includes('previous_response');
+
+      if (isPredictionHistoryError) {
         console.warn('[Vault AI] Prediction history error detected, clearing response ID');
         await this.plugin.chatHistory.updateLMStudioResponseId(this.currentConversationId!, undefined as any);
-        new Notice('LM Studio conversation history error. The conversation has been reset - please try again.');
       }
 
-      const errorMsg: ChatMessage = {
-        role: 'assistant',
-        content: `I encountered an error: ${error}. Please try again.`,
-        timestamp: Date.now(),
-      };
+      // If we have partial content, save it instead of just the error
+      if (partialContent.trim()) {
+        const assistantMsg: ChatMessage = {
+          role: 'assistant',
+          content: partialContent,
+          timestamp: Date.now(),
+          sources: searchResult.sources,
+          searchSteps: searchResult.steps,
+          reasoning: partialReasoning || undefined,
+        };
+        await this.plugin.chatHistory.addMessage(this.currentConversationId!, assistantMsg);
 
-      await this.plugin.chatHistory.addMessage(this.currentConversationId!, errorMsg);
+        // Show a notice about the error but don't lose the content
+        if (isPredictionHistoryError) {
+          new Notice('LM Studio had an internal error, but the response was saved.');
+        } else {
+          new Notice(`Stream ended with error, but partial response was saved.`);
+        }
+      } else {
+        // No content was streamed, save error message
+        const errorMsg: ChatMessage = {
+          role: 'assistant',
+          content: `I encountered an error: ${error}. Please try again.`,
+          timestamp: Date.now(),
+        };
+        await this.plugin.chatHistory.addMessage(this.currentConversationId!, errorMsg);
+
+        if (isPredictionHistoryError) {
+          new Notice('LM Studio conversation history error. The conversation has been reset - please try again.');
+        }
+      }
     } finally {
       this.isProcessing = false;
       this.view.setConnectionStatus('ready');


### PR DESCRIPTION
## Summary
Improved error handling in chat streaming to preserve any content that was successfully streamed before an error occurred, rather than discarding it and showing only an error message.

## Key Changes
- **Capture partial content**: Save `streamingContent` and `streamingReasoning` before finalizing the message on error
- **Conditional message saving**: 
  - If partial content exists, save it as a valid assistant message with a user-friendly notice
  - If no content was streamed, fall back to the original error message behavior
- **Better error messaging**: Differentiate between LM Studio prediction history errors and other stream errors with appropriate user notices
- **Applied to both chat handlers**: Updated error handling in both MCP chat and LMStudio chat methods (lines ~1009 and ~1136)
- **Refactored error detection**: Extract `isPredictionHistoryError` check to avoid duplication and improve readability

## Implementation Details
- Partial content is captured immediately after the error is caught, before `finalizeStreamingMessage()` is called
- The `sources` and `searchSteps` metadata are preserved in the LMStudio handler when saving partial content
- User notices now indicate whether content was saved or if a full retry is needed
- Prediction history errors still trigger the response ID reset, but with improved messaging

https://claude.ai/code/session_01SqhBek4i7Bn6J4sXDEHDQk